### PR TITLE
fix Bluetooth address to Random Static Address class

### DIFF
--- a/bluetooth.c
+++ b/bluetooth.c
@@ -103,6 +103,8 @@ static void generate_random_mac_address(uint8_t *mac) {
     srand(time(0)); // NOLINT(cert-msc51-cpp)
     for (int i = 0; i < 6; i++)
         mac[i] = rand() % 255; // NOLINT(cert-msc50-cpp)
+        
+    mac[0] |= 0xC0;  // set to Bluetooth Random Static Address, see https://www.novelbits.io/bluetooth-address-privacy-ble/ or section 1.3 of the Bluetooth specification (5.3)
 }
 
 /*


### PR DESCRIPTION
The Bluetooth standard defines several classes of MAC addresses. This pull request sets the random generated MAC address to the class: static random address.

For BLE advertisement data, the MAC address should be the public address or a static random address. Private random address may prevent detection of the advertisement data. 

See https://www.novelbits.io/bluetooth-address-privacy-ble/ or section 1.3 of the Bluetooth specification (5.3):

"_IMPORTANT NOTE: All Bluetooth devices must use one of either type: a Public Address or a Random Static Address.
The next type of address (Private Address) is optional and is solely used to address privacy concerns (i.e. device may use one of them in addition to either a Public or Random Static Address)._"