### PR TITLE
Reset HCI before setting parameters

### DIFF
--- a/bluetooth.c
+++ b/bluetooth.c
@@ -114,6 +114,12 @@ static void generate_random_mac_address(uint8_t *mac) {
  * (In version 5.2, they appear to have been moved to Vol 4, Part E, Chapter 7.8).
  */
 
+static void hci_reset(int dd) {
+    uint8_t ogf = OGF_HOST_CTL; // Opcode Group Field. LE Controller Commands
+    uint16_t ocf = OCF_RESET;
+    send_cmd(dd, ogf, ocf, NULL, 0);
+}
+
 static void hci_le_read_local_supported_features(int dd) {
     uint8_t ogf = OGF_LE_CTL; // Opcode Group Field. LE Controller Commands
     uint16_t ocf = OCF_LE_READ_LOCAL_SUPPORTED_FEATURES;
@@ -346,21 +352,25 @@ void init_bluetooth(struct config_data *config) {
     generate_random_mac_address(mac);
 
     device_descriptor = open_hci_device();
+    hci_reset(device_descriptor);
     stop_transmit(config);
 
     hci_le_read_local_supported_features(device_descriptor);
 
     if (config->use_btl) {
+        hci_reset(device_descriptor);
         hci_le_set_advertising_parameters(device_descriptor, 100);
         hci_le_set_random_address(device_descriptor, mac);
     }
 
     if (config->use_bt4) {
+        hci_reset(device_descriptor);
         hci_le_set_extended_advertising_parameters(device_descriptor, config->handle_bt4, 300, false);
         hci_le_set_advertising_set_random_address(device_descriptor, config->handle_bt4, mac);
     }
 
     if (config->use_bt5) {
+        hci_reset(device_descriptor);
         hci_le_set_extended_advertising_parameters(device_descriptor, config->handle_bt5, 950, true);
         hci_le_set_advertising_set_random_address(device_descriptor, config->handle_bt5, mac);
     }


### PR DESCRIPTION
Needed to clear HCI state on some versions/distributions. Without this, the HCI could be in an incompatible mode and not accept commands. On Ubuntu 18.04 (Nvidia JetPack 4.6) with an AX200, the output looked like this before the fix:
```
~/git/transmitter-linux/build$ sudo ./transmit 4
Command 0xA returned error 0xC
Command 0x39 returned error 0xC
Supported Low Energy Bluetooth features:
        Features: 0xff 0x59 0x00 0x00 0x00 0x00 0x00 0x00
          LE Encryption
          Connection Parameter Request Procedure
          Extended Reject Indication
          Slave-initiated Features Exchange
          LE Ping
          LE Data Packet Length Extension
          LL Privacy
          Extended Scanner Filter Policies
          LE 2M PHY
          LE Coded PHY
          LE Extended Advertising
          Channel Selection Algorithm #2
Command 0x36 returned error 0xC
The transmit power is set to 255 dBm
Command 0x39 returned error 0xC
Command 0x37 returned error 0xC
Command 0x37 returned error 0xC
Command 0x37 returned error 0xC
Command 0x37 returned error 0xC
Command 0x37 returned error 0xC
Command 0x37 returned error 0xC
Command 0x37 returned error 0xC
Command 0x37 returned error 0xC
Command 0x37 returned error 0xC
Command 0xA returned error 0xC
Command 0x39 returned error 0xC
```
And this after
```
~/git/transmitter-linux/build$ sudo ./transmit 4
Supported Low Energy Bluetooth features:
        Features: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Command 0xA returned error 0xC
Command 0x39 returned error 0xC
Supported Low Energy Bluetooth features:
        Features: 0xff 0x59 0x00 0x00 0x00 0x00 0x00 0x00
          LE Encryption
          Connection Parameter Request Procedure
          Extended Reject Indication
          Slave-initiated Features Exchange
          LE Ping
          LE Data Packet Length Extension
          LL Privacy
          Extended Scanner Filter Policies
          LE 2M PHY
          LE Coded PHY
          LE Extended Advertising
          Channel Selection Algorithm #2
Supported Low Energy Bluetooth features:
        Features: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
The transmit power is set to 7 dBm
Command 0xA returned error 0xC
```
Additionally, `btmon` showed the failures, then successes. And a drone scanner app also confirmed that no advertisements were received before the fix but were received after the fix.