### PR TITLE
[Git] Use https or relative path for submodule urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "hostapd"]
 	path = hostapd
-	url = git://w1.fi/hostap.git
+	url = https://w1.fi/hostap.git
 [submodule "bluez"]
 	path = bluez
-	url = git://git.kernel.org/pub/scm/bluetooth/bluez.git
+	url = https://git.kernel.org/pub/scm/bluetooth/bluez.git
 [submodule "core-c"]
 	path = core-c
-	url = git@github.com:opendroneid/opendroneid-core-c.git
+	url = ../opendroneid-core-c.git
 [submodule "gpsd"]
 	path = gpsd
 	url = https://gitlab.com/gpsd/gpsd.git


### PR DESCRIPTION
Hello,

Wanting to try out transmitter-linux i cloned recursively this repo and the cloning failed on the sub modules.

The issue is that i used a computer of which i didn't authorize the ssh keys on github.

The simple fix is of course to add the public key to github.

As this is a public repo it would make sense to be able to clone it without a github account. So i replaced the sub module urls with https urls instead of ssh ones.

For the opendroneid-core-c module, as it is in the same repo, i used a relative path, this way
- if someone clones transmitter-linux using https, opendroneid-core-c will be cloned using https as well
- if someone clones using ssh, the sub module will be cloned using ssh as well
- in case one day you'd move the whole opendroneid project to some other git server, the relative url wouldn't change

The hostapd and bluez urls work with anonymous ssh, so i could revert this part of the PR if you prefer.

Thanks for this nice project !